### PR TITLE
Yet more static/watch copy fixes...maybe got it this time? lol.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rollup-config-badger-den",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-config-badger-den",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@foundryvtt/foundryvtt-cli": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-config-badger-den",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/trioderegion/rollup-config-badger-den",
   "description": "Configurable rollup plugin/template for bundling FVTT modules.",
   "license": "MIT",

--- a/src/Manifest.mjs
+++ b/src/Manifest.mjs
@@ -39,10 +39,12 @@ import deepmerge from "deepmerge";
 
 /**
  * Top level definition of this module's root files, or entry points. Language files should follow the country code naming convention, e.g. `en.json` or `ja.json`, for proper detection.
+ * All files/globstrings listed in this section, _except_ for compendia, will be watched for changes and trigger rebundles. Compendium entries are unpacked (if requested) prior to any cleaning operation of the output folder, and packed _after_ said cleaning operation.
  *
  * @typedef {Object} EntryPointJSON
  * @prop {globstring} main paths for top level module files (e.g. `init.mjs` or `[module name].mjs`)
- * @prop {globstring} [lang] paths for language files with `[country code].json` format (e.g. `en.json`), which are treated as static files during bundling
+ * @prop {globstring} [lang] paths for language files with `[country code].json` format (e.g. `en.json`)
+ * @prop {globstring} [templates] paths for handlebars template files (.hbs or .html)
  * @prop {CompendiaJSON} [compendia] folder paths containing leveldb source files, with equivalent relative paths used as location for profile's built package databases
  */
 
@@ -66,7 +68,7 @@ import deepmerge from "deepmerge";
  * @prop {string} description directly added to resulting manifest 
  * @prop {string} [projectUrl]
  * @prop {EntryPointJSON} entryPoints
- * @prop {globstring} [static] file/folder paths to be directly copied to built package
+ * @prop {globstring} [static] file/folder paths to be directly copied to built package _once_ upon initial bundle only (not re-copied on watch trigger)
  * @prop {Object.<string, DenProfileJSON>} profile list of profile objects keyed by its name, such as 'release' or 'dev'
  * @prop {object} [dependencies] inner string arrays are treated as `[min, verified, max]` versions
  * @prop {string[]} [dependencies.core=[]]

--- a/src/demo-module/src/templates/another-template.hbs
+++ b/src/demo-module/src/templates/another-template.hbs
@@ -1,0 +1,3 @@
+<p>Hello World!</p>
+  <p>Hello World</p>
+  <p>Hello World</p>

--- a/src/demo-module/src/templates/template.hbs
+++ b/src/demo-module/src/templates/template.hbs
@@ -1,4 +1,3 @@
 <div>
   <p>Hello World</p>
-  <p>Foo</p>
 </div>

--- a/src/rollup-plugin-badger-den.mjs
+++ b/src/rollup-plugin-badger-den.mjs
@@ -61,6 +61,8 @@ function getPlugin({ config, scssPlug, compressPlug, options } = {}) {
     },
     options: options ?? {},
     ranOnce: false,
+    watchEcho: true,
+    loadEcho: false,
 
     socketDetected: false,
     storageDetected: false,
@@ -148,7 +150,7 @@ function getPlugin({ config, scssPlug, compressPlug, options } = {}) {
           copy({
             ...copyOpts,
             targets: staticLangs,
-            watch: this.meta.watchMode ? staticLangs.map( e => e.src ) : false,
+            //watch: this.meta.watchMode ? staticLangs.map( e => e.src ) : false,
           }))
       }
 
@@ -157,7 +159,7 @@ function getPlugin({ config, scssPlug, compressPlug, options } = {}) {
           copy({
             ...copyOpts,
             targets: staticTemplates,
-            watch: this.meta.watchMode ? staticTemplates.map( e => e.src ) : false,
+            //watch: this.meta.watchMode ? staticTemplates.map( e => e.src ) : false,
           }))
       }
 
@@ -218,16 +220,24 @@ function getPlugin({ config, scssPlug, compressPlug, options } = {}) {
       const merged = merge(opts, output);
       return merged;
     },
-    buildStart(){
+    load(id){
+      if (api.loadEcho) console.log('Loading:', id);
       if (this.meta.watchMode) {
-        const styleWatch = config.styleSources.map( s => {
-          const file = api.makeInclude(s);
-          this.addWatchFile(file)
+        const watch = (path) => {
+          const file = api.makeInclude(path);
+          this.addWatchFile(file);
           return file;
-        })
-        console.log("Watching Styles:", styleWatch);
-        console.log("Watching Languages:", api.cache.manifest.languages.map( l => l.path ));
-        console.log("Watching Templates:", api.cache.manifest.templates);
+        };
+
+        const styleWatch = config.styleSources.map(watch);
+        const langWatch = api.cache.manifest.languages.map( l => l.path ).map(watch);
+        const templateWatch = api.cache.manifest.templates.map(watch);
+        if (api.watchEcho) {
+          console.log("Watching Styles:", styleWatch);
+          console.log("Watching Languages:", langWatch);
+          console.log("Watching Templates:", templateWatch);
+          api.watchEcho = false;
+        }
       }
     },
     buildEnd() {


### PR DESCRIPTION
* Moved the non-code watch file additions to `load`
* Added (non-exposed currently) plugin options related to verbosity
* `copy-watch` plugin is still in use, but no longer watching. Will be removed and rolled back to just `copy` in coming versions.